### PR TITLE
fix a typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pip install opencv-python tensorboard pytorch_fid ipdb imageio
 ```
 pip install gym pybullet
 
-cd Envs
+cd envs
 
 git clone https://github.com/AaronAnima/EbOR # install Example-based Object Rearrangement (EbOR) environments
 
@@ -79,7 +79,7 @@ cd ../../
 
 ### Install *Room Rearrangement* Environment
 
-Please follow the README in [this page](https://github.com/AaronAnima/TarGF/tree/main/Envs/Room).
+Please follow the README in [this page](https://github.com/AaronAnima/TarGF/tree/main/envs/Room).
 
 If you do not need to run this experiment, you can skip this procedure. 
 

--- a/envs/Room/README.md
+++ b/envs/Room/README.md
@@ -7,7 +7,7 @@ First download the `3DFRONT` dataset preprocessed by us:
 **[2022/8/31 update] Due to the license issue, we temporarily canceled the sharing link below. If you need this dataset urgently, please email the authors.**
 
 ```
-cd Targf/Envs/Room
+cd Targf/envs/Room
 
 wget https://www.dropbox.com/s/7j8f3dvn976hmaf/data.zip
 


### PR DESCRIPTION
Some typos. You changed the directory name but didn't change them in the readme instructions.